### PR TITLE
fix StyledInput example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ You can just pass a `placeholder` prop into the `styled-component`. It will pass
 
 ```JSX
 // Render a styled input with a placeholder of "@liqueflies"
-<Input placeholder="@liqueflies" type="text" />
+<StyledInput placeholder="@liqueflies" type="text" />
 ```
 ### Adapting based on props
 


### PR DESCRIPTION
Correct me if I'm wrong, but shouldn't `input` be `StyledInput`, in order to create an instance of the styled component in the example:

```
// Create an <StyledInput> component that'll render an <input> tag with some styles
const StyledInput = styled.input`
  font-size: 1.25em;
  padding: 0.5em;
  margin: 0.5em;
  color: palevioletred;
  background: papayawhip;
  border: none;
  border-radius: 3px;

  &:hover {
    box-shadow: inset 1px 1px 2px rgba(0,0,0,0.1);
  }
`;
```