### PR TITLE
Add Extension Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,19 +176,29 @@ export default StyledLink;
 
 Let's say someplace else you want to use your button component, but just in this one case you want the color and border color to be `tomato` instead of `palevioletred`. Now you _could_ pass in an interpolated function and change them based on some props, but that's quite a lot of effort for overriding the styles once.
 
-To do this in an easier way you can call `styled` as a function and pass in the previous component. You style that like any other styled-component. It overrides duplicate styles from the initial component and keeps the others around:
+To do this in an easier way you can call `StyledComponent.extend` as a function and pass in the extended style. It overrides duplicate styles from the initial component and keeps the others around:
 
 ```JSX
 // Tomatobutton.js
 
 import StyledButton from './StyledButton';
 
-const TomatoButton = styled(StyledButton)`
+const TomatoButton = StyledButton.extend`
   color: tomato;
   border-color: tomato;
 `;
 
 export default TomatoButton;
+```
+
+### withComponent
+Let's say you have a `button` and an `a` tag. You want them to share the exact same style. This is achievable with `.withComponent`.
+```JSX
+const Button = styled.button`
+  background: green;
+  color: white;
+`
+const Link = Button.withComponent('a')
 ```
 
 ### injectGlobal

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-plugin-transform-class-properties": "^6.19.0",
     "babel-plugin-transform-object-rest-spread": "^6.20.2",
     "babel-preset-latest": "^6.16.0",
+    "chai": "^4.1.2",
     "chokidar": "^1.6.1",
     "danger": "^0.7.5",
     "eslint": "^3.12.2",

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -40,6 +40,9 @@ export default (ComponentStyle) => {
           const componentProps = Object.assign({}, this.$props)
           return this.generateAndInjectStyles(componentProps)
         }
+      },
+      withComponent(newTarget) {
+        return createStyledComponent(newTarget, rules, props);
       }
     }
 

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -41,6 +41,9 @@ export default (ComponentStyle) => {
           return this.generateAndInjectStyles(componentProps)
         }
       },
+      extend(extendedRules) {
+        return createStyledComponent(target, rules.slice().concat(extendedRules), props);
+      },
       withComponent(newTarget) {
         return createStyledComponent(newTarget, rules, props);
       }

--- a/src/test/extending-components.test.js
+++ b/src/test/extending-components.test.js
@@ -5,7 +5,7 @@ import { resetStyled, expectCSSMatches } from './utils'
 
 let styled
 
-describe('extending', () => {
+describe('extending components', () => {
   /**
    * Make sure the setup is the same for every test
    */

--- a/src/test/extending-styles.test.js
+++ b/src/test/extending-styles.test.js
@@ -1,0 +1,21 @@
+import Vue from 'vue'
+
+import { resetStyled, expectCSSMatches } from './utils'
+
+let styled
+
+describe('extending styled', () => {
+  beforeEach(() => {
+    styled = resetStyled()
+  })
+
+  it('should append extended styled to the original class', () => {
+    const Base = styled.div`color: blue;`
+    const Extended = Base.extend`background: green;`
+
+    const b = new Vue(Base).$mount()
+    const e = new Vue(Extended).$mount()
+
+    expectCSSMatches('.a {color: blue;background: green;}')
+  })
+})

--- a/src/test/withComponent.test.js
+++ b/src/test/withComponent.test.js
@@ -1,0 +1,23 @@
+import Vue from 'vue'
+import { assert } from 'chai'
+
+import { resetStyled } from './utils'
+
+let styled
+
+describe('extending styled', () => {
+  beforeEach(() => {
+    styled = resetStyled()
+  })
+
+  it('should change the target element', () => {
+    const OldTarget = styled.div`color: blue;`
+    const NewTarget = OldTarget.withComponent('a')
+
+    const o = new Vue(OldTarget).$mount()
+    const n = new Vue(NewTarget).$mount()
+
+    assert(o._vnode.tag === 'div');
+    assert(n._vnode.tag === 'a');
+  })
+})


### PR DESCRIPTION
The purpose of this PR is to provide a more consistent functionality to the documentation of styled-components.

https://www.styled-components.com/docs/basics#extending-styles

**New Methods:**
```JSX
MyComponent.extend``
MyComponent.withComponent('a')
```