### PR TITLE
Fix Form Inputs

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -20,6 +20,7 @@ export default (ComponentStyle) => {
             },
             on: {
               input: (event) => {
+                this.value = event.target.value
                 this.$emit('input', event.target.value)
               },
               click: (event) => {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -31,21 +31,28 @@ export default (ComponentStyle) => {
         )
       },
       methods: {
-        generateAndInjectStyles (componentProps) {
-          return componentStyle.generateAndInjectStyles(componentProps)
+        generateAndInjectStyles (style, props) {
+          return style.generateAndInjectStyles(props)
         }
       },
       computed: {
         generatedClassName () {
           const componentProps = Object.assign({}, this.$props)
-          return this.generateAndInjectStyles(componentProps)
+          return this.generateAndInjectStyles(componentStyle, componentProps)
         }
       },
-      extend(extendedRules) {
-        return createStyledComponent(target, rules.slice().concat(extendedRules), props);
+      extend(...extendedRules) {
+        const extended = []
+
+        extendedRules[0].forEach((line, key) => {
+          extended.push(line)
+          extended.push(extendedRules[key + 1])
+        });
+
+        return createStyledComponent(target, rules.slice().concat(extended), mergedProps)
       },
       withComponent(newTarget) {
-        return createStyledComponent(newTarget, rules, props);
+        return createStyledComponent(newTarget, rules, mergedProps);
       }
     }
 

--- a/src/test/extending-styles.test.js
+++ b/src/test/extending-styles.test.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { assert } from 'chai'
 
 import { resetStyled, expectCSSMatches } from './utils'
 
@@ -15,6 +16,9 @@ describe('extending styled', () => {
 
     const b = new Vue(Base).$mount()
     const e = new Vue(Extended).$mount()
+
+    assert(b._vnode.data.class[0] === 'a')
+    assert(e._vnode.data.class[0] === 'b')
 
     expectCSSMatches('.a {color: blue;} .b {color: blue;background: green;}')
   })

--- a/src/test/extending-styles.test.js
+++ b/src/test/extending-styles.test.js
@@ -16,6 +16,6 @@ describe('extending styled', () => {
     const b = new Vue(Base).$mount()
     const e = new Vue(Extended).$mount()
 
-    expectCSSMatches('.a {color: blue;background: green;}')
+    expectCSSMatches('.a {color: blue;} .b {color: blue;background: green;}')
   })
 })


### PR DESCRIPTION
This PR addresses https://github.com/styled-components/vue-styled-components/issues/36.

The problem is that when the value changes, although it propagates to the parent component with an event, it does not set the value for the style component. This means that a select box will not show the selected value. The fix for this is simple, just set the value on the input event.