### PR TITLE
Remove fbjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "css-in-js"
   ],
   "dependencies": {
-    "fbjs": "^0.8.9",
     "glamor": "^2.20.24",
     "inline-style-prefixer": "^2.0.5",
     "lodash.isplainobject": "^4.0.6",

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -1,10 +1,10 @@
-import hyphenate from 'fbjs/lib/hyphenateStyleName'
 import isPlainObject from 'lodash.isplainobject'
+import hyphenateStyleName from './hyphenateStyleName'
 
 export const objToCss = (obj, prevKey) => {
   const css = Object.keys(obj).map(key => {
     if (isPlainObject(obj[key])) return objToCss(obj[key], key)
-    return `${hyphenate(key)}: ${obj[key]};`
+    return `${hyphenateStyleName(key)}: ${obj[key]};`
   }).join(' ')
   return prevKey ? `${prevKey} {
   ${css}

--- a/src/utils/hyphenateStyleName.js
+++ b/src/utils/hyphenateStyleName.js
@@ -1,0 +1,12 @@
+const _uppercasePattern = /([A-Z])/g
+const msPattern = /^ms-/
+
+function hyphenate (string) {
+  return string.replace(_uppercasePattern, '-$1').toLowerCase()
+}
+
+function hyphenateStyleName (string) {
+  return hyphenate(string).replace(msPattern, '-ms-')
+}
+
+module.exports = hyphenateStyleName


### PR DESCRIPTION
`fbjs` was only being used for the `hyphenateStyleName` and (internally) the `hyphenate` function.

This commit removes the need for this library by extracting those functions into their own util library.