### PR TITLE
Fix v-model behaviour in Input and Select styled components

### DIFF
--- a/example/devServer.js
+++ b/example/devServer.js
@@ -30,7 +30,7 @@ app.get('/with-perf.html', (req, res) => {
 })
 
 app.get('/*', (req, res) => {
-  res.sendFile(path.join(__dirname, 'index.html'))
+  res.sendFile(path.join(__dirname, req.originalUrl || 'index.html'))
 })
 
 app.listen(port, error => {

--- a/example/form.html
+++ b/example/form.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Form Example</title>
+</head>
+<body>
+<h1>Form Example</h1>
+<div id="container"></div>
+<script src="https://unpkg.com/vue@2.2.4"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.24/browser.min.js"></script>
+<script src="/vue-styled-components.js"></script>
+<script type="text/babel">
+  // Create a global style
+  styled.injectGlobal`
+      body {
+        background-color: #fefefe;
+      }
+    `
+
+  // Create a <Wrapper> vue component that renders a <section> with
+  // some padding and a papayawhip background
+  const Wrapper = styled.default.section`
+      padding: 4em;
+      background: papayawhip;
+    `
+
+  const StyledSelect = styled.default.select`
+        color:red;
+    `
+
+  const StyledInput = styled.default.input`
+        color:red;
+        font-size:20px;
+    `
+
+  const StyledButton = styled.default.button`
+        color:red;
+        font-size:20px;
+    `
+
+  new Vue({
+    el: '#container',
+    data () {
+      return {
+        externalValue: '1',
+        isSelected: false
+      }
+    },
+    components: {
+      StyledInput,
+      StyledSelect,
+      StyledButton,
+      Wrapper
+    },
+    methods: {
+      increaseValue () {
+        this.externalValue++
+      }
+    },
+    template: `<wrapper>
+<StyledInput v-model="externalValue"/>
+<StyledSelect v-model="externalValue">
+    <option value="1">1</option>
+    <option value="2">2</option>
+    <option value="3">3</option>
+</StyledSelect>
+<input v-model="externalValue" />
+<StyledButton v-on:click="increaseValue">Click me</StyledButton>
+<button v-on:click="increaseValue">Click me</button>
+</wrapper>`
+  })
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "rollup-plugin-uglify": "^1.0.1",
     "rollup-plugin-visualizer": "^0.1.5",
     "rollup-plugin-vue2": "^0.8.0",
-    "vue": "^2.2.4"
+    "vue": "^2.5.17"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
The current implementation shows a weird behaviour when one or more inputs are pointing to the same data attribute via `v-model`. A concrete example is when there's a native `<input>` and a styled `Input` pointing to the same data using `v-model`, the native input is always in sync with the expression inside `v-model`, but the StyledComponent loses track of it, meaning it gets out of sync. It also fixes the problem of a styled `select` not having an initial option selected.

Here is an example of said behaviour: https://codesandbox.io/s/wnj07wwvw5, by changing the `select` value, the 2nd input (native one) gets updated, while the 1st input (styled) gets out of sync. However, by editing the value of the 2nd input, they all get back in sync again.

Based on bootstrap-vue project, this commit implements a similar (but lighter) solution which maintains a `localValue` and emits events when the `localValue` changes (https://github.com/bootstrap-vue/bootstrap-vue/blob/dev/src/components/form-select/form-select.js). It also doesn't require implementing yet another event for `change`.

This is not a complete solution since checkboxes and radio buttons haven't been tested and they most likely don't work with `v-model`, it's also emitting as many events as components exist above the inputs, which makes it quite difficult to have any real usage in production.

Going forward, I suspect the best way to handle different styled elements is by creating different render functions for each, and deciding when to emit certain events depending on the component.

Fixes #53 