### PR TITLE
add ThemeProvider component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-styled-components",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
 import keyframes from './constructors/keyframes'
 import injectGlobal from './constructors/injectGlobal'
+import ThemeProvider from './providers/ThemeProvider'
 
 import _styledComponent from './models/StyledComponent'
 import _componentStyle from './models/ComponentStyle'
@@ -13,4 +14,4 @@ const styled = _styled(
 
 export default styled
 
-export { css, injectGlobal, keyframes }
+export { css, injectGlobal, keyframes, ThemeProvider }

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -8,6 +8,11 @@ export default (ComponentStyle) => {
     const componentStyle = new ComponentStyle(rules)
 
     const StyledComponent = {
+      inject: {
+        theme: {
+          default: {}
+        }
+      },
       props: mergedProps,
       render: function (createElement) {
         const children = []
@@ -18,6 +23,7 @@ export default (ComponentStyle) => {
             children.push(createElement('template', { slot }, this.$slots[slot]))
           }
         }
+
         return createElement(
           target,
           {
@@ -46,7 +52,7 @@ export default (ComponentStyle) => {
       },
       computed: {
         generatedClassName () {
-          const componentProps = Object.assign({}, this.$props)
+          const componentProps = Object.assign({ theme: this.theme }, this.$props)
           return this.generateAndInjectStyles(componentProps)
         }
       },

--- a/src/providers/ThemeProvider.js
+++ b/src/providers/ThemeProvider.js
@@ -1,0 +1,15 @@
+export default {
+  name: 'ThemeProvider',
+  props: {
+    theme: Object
+  },
+  provide () {
+    return {
+      theme: this.theme
+    }
+  },
+  render: function (createElement) {
+    return createElement('div', {}, this.$slots.default)
+  }
+}
+

--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 
 import { resetStyled, expectCSSMatches } from './utils'
+import ThemeProvider from "../providers/ThemeProvider"
 
 let styled
 
@@ -30,5 +31,33 @@ describe('props', () => {
       }
     }).$mount()
     expectCSSMatches('.a {color: red;}')
+  })
+
+  it('should add any injected theme to the component', () => {
+    const theme = {
+      blue: "blue",
+    }
+
+    const Comp = styled.div`
+      color: ${props => props.theme.blue};
+    `
+    const Themed = {
+      render: function(createElement) {
+        return createElement(
+          ThemeProvider,
+          {
+            props: {
+              theme,
+            },
+          },
+          [
+            Comp
+          ]
+        )
+      }
+    }
+
+    const vm = new Vue(Themed).$mount()
+    expectCSSMatches('.a {color: blue;}')
   })
 })

--- a/src/test/props.test.js
+++ b/src/test/props.test.js
@@ -51,7 +51,7 @@ describe('props', () => {
             },
           },
           [
-            Comp
+            createElement(Comp)
           ]
         )
       }

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -20,6 +20,7 @@ export const resetStyled = () => {
 }
 
 const stripWhitespace = str => str.trim().replace(/\s+/g, ' ')
+
 export const expectCSSMatches = (
   expectation,
   opts = {}


### PR DESCRIPTION
Use the inject/provide api to create a ThemeProvider component, injecting `theme` into the props of a StyledComponent.

I was unable to get the test that I wrote to pass, direction on what I'm doing wrong would be appreciated.

Would resolve #26. 