### PR TITLE
Add check to avoid null pointer exception

### DIFF
--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -20,7 +20,9 @@ export default (ComponentStyle) => {
             },
             on: {
               input: (event) => {
-                this.$emit('input', event.target.value)
+                if (event.target) {
+                  this.$emit('input', event.target.value)
+                }
               },
               click: (event) => {
                 this.$emit('click', event)


### PR DESCRIPTION
Unfortunately, there is always a possibility that one receives an input event without `target`, which would result in the following error: `[Vue warn]: Error in event handler for "input": "TypeError: Cannot read property 'value' of undefined"`