### PR TITLE
fixed small typo in code example in readme (vue specific)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Remember to register `ThemeProvider` locally.
 Add your `ThemeProvider` component:
 
 ```JSX
-  <theme-provider theme="{
+  <theme-provider :theme="{
     primary: 'palevioletred'
   }">
     <wrapper>


### PR DESCRIPTION
When implementing I copied the code example and noticed I had an error in my console "expecting Object, received String" the code example requires the `:` at the front to interpret it as an Object.