### PR TITLE
Implement attributes parameter while creating a styled component

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,21 @@ And into your `Wrapper` component:
   `;
 ```
 
+### HTML Attributes
+
+While creating a styled component you can pass an object that describes html attibutes of this component.
+
+```JSX
+import styled from 'vue-styled-components';
+
+const StyledImage = styled('img', {}, { src: 'image.jpg', alt: 'Test image' })`
+  width: 50px;
+  height: 50px;
+`;
+
+export default StyledImage;
+```
+
 ### Style component constructors as `router-link`
 
 You can style also Vue component constructors as `router-link` from `vue-router` and other components

--- a/src/constructors/styled.js
+++ b/src/constructors/styled.js
@@ -2,9 +2,9 @@ import css from './css'
 import domElements from '../utils/domElements'
 
 export default (createStyledComponent) => {
-  const styled = (tagName, props = {}) =>
+  const styled = (tagName, props = {}, attrs = {}) =>
     (cssRules, ...interpolations) => (
-      createStyledComponent(tagName, css(cssRules, ...interpolations), props)
+      createStyledComponent(tagName, css(cssRules, ...interpolations), props, attrs)
     )
 
   domElements.forEach((domElement) => {

--- a/src/models/StyledComponent.js
+++ b/src/models/StyledComponent.js
@@ -1,11 +1,14 @@
 export default (ComponentStyle) => {
-  const createStyledComponent = (target, rules, props) => {
+  const createStyledComponent = (target, rules, props, attrs) => {
     const prevProps = target && typeof target !== 'string'
       ? (typeof target === 'object' ? target.props : (typeof target === 'function' ? target.options.props : {}))
       : {}
     const mergedProps = Object.assign({}, prevProps, props)
 
     const componentStyle = new ComponentStyle(rules)
+
+    // Null check
+    const attributes = attrs || {}
 
     const StyledComponent = {
       inject: {
@@ -30,6 +33,7 @@ export default (ComponentStyle) => {
           target,
           {
             class: [this.generatedClassName],
+            attrs: attributes,
             props: this.$props,
             domProps: {
               value: this.value

--- a/src/test/attributes.test.js
+++ b/src/test/attributes.test.js
@@ -1,0 +1,58 @@
+import Vue from 'vue/dist/vue';
+import expect from 'expect'
+
+import styleSheet from '../models/StyleSheet'
+import { resetStyled, expectCSSMatches } from './utils'
+
+let styled
+
+describe('attributes', () => {
+  /**
+   * Make sure the setup is the same for every test
+   */
+  beforeEach(() => {
+    styled = resetStyled()
+  })
+
+  it('should add html attributes to an element', () => {
+    const Comp = styled('img', {}, { src: 'image.jpg' })`
+      width: 50px;
+    `
+    const vm = new Vue(Comp).$mount()
+    expect(vm._vnode.data.attrs).toEqual({ src: 'image.jpg' })
+  })
+
+  it('should add several html attributes to an element', () => {
+    const Comp = styled('img', {}, { src: 'image.jpg', alt: 'Test image' })`
+      width: 50px;
+    `
+    const vm = new Vue(Comp).$mount()
+    expect(vm._vnode.data.attrs).toEqual({ src: 'image.jpg', alt: 'Test image' })
+  })
+
+  it('should work as expected with empty attributes object provided', () => {
+    const Comp = styled('img', {}, {})`
+      width: 50px;
+    `
+    const vm = new Vue(Comp).$mount()
+    expectCSSMatches('.a {width: 50px;}')
+  })
+
+  it('should work as expected with null attributes object provided', () => {
+    const Comp = styled('img', {}, null)`
+      width: 50px;
+    `
+    const vm = new Vue(Comp).$mount()
+    expectCSSMatches('.a {width: 50px;}')
+    expect(vm._vnode.data.attrs).toEqual({})
+  })
+
+  it('should work as expected without attributes provided', () => {
+    const Comp = styled('img')`
+      width: 50px;
+    `
+    const vm = new Vue(Comp).$mount()
+    expectCSSMatches('.a {width: 50px;}')
+    expect(vm._vnode.data.attrs).toEqual({})
+  })
+})


### PR DESCRIPTION
This is the first implementation that supports only a plain object that describes attrs. #68 

```JSX
import styled from 'vue-styled-components';
const StyledImage = styled('img', {}, { src: 'image.jpg', alt: 'Test image' })`
  width: 50px;
  height: 50px;
`;
export default StyledImage;
```

I'm planning to extend it similarly to the original styled components (having an attr key that takes a function):

```JSX
const Input = styled.input.attrs(props => ({
  type: 'text',
  size: props.small ? 5 : undefined,
}))`
  border-radius: 3px;
  border: 1px solid palevioletred;
  display: block;
  margin: 0 0 1em;
  padding: ${props => props.padding};

  ::placeholder {
    color: palevioletred;
  }
`
```