### PR TITLE
[x] Removed namespace from keyframe

### DIFF
--- a/src/models/ComponentStyle.js
+++ b/src/models/ComponentStyle.js
@@ -10,6 +10,7 @@ export default (nameGenerator) => {
   class ComponentStyle {
     constructor (rules) {
       this.rules = rules
+      stylis.set({ keyframe: false })
       if (!styleSheet.injected) styleSheet.inject()
       this.insertedRule = styleSheet.insert('')
     }


### PR DESCRIPTION
Stylis now automatically add a prefix to animation, had to disable in order to keep working.