### PR TITLE
generateAndInjectStyles error appears when inheriting from components that are not styled components

### DIFF
--- a/src/test/basic.test.js
+++ b/src/test/basic.test.js
@@ -34,6 +34,11 @@ describe('basic', () => {
     expect(() => styled.notExistTag``).toThrow()
   })
 
+  it('should allow for inheriting components that are not styled', () => {
+    const componentConfig = { name: 'Parent', template: '<div><slot/></div>', methods: {} }
+    expect(() => styled(componentConfig, {})``).toNotThrow()
+  })
+
   // it('should generate an empty tag once rendered', () => {
   //   const Comp = styled.div``
   //   const vm = new Vue(Comp).$mount()

--- a/src/utils/isStyledComponent.js
+++ b/src/utils/isStyledComponent.js
@@ -1,5 +1,5 @@
 export default function isStyledComponent (target) {
   return target &&
     target.methods &&
-    typeof target.methods.generateAndInjectStyles() === 'string'
+    typeof target.methods.generateAndInjectStyles === 'function'
 }


### PR DESCRIPTION
This fixes issues #95 and #90 

After fixing the error message with typechecking, it was necessary to stop invoking the function `generateAndInjectStyles` without any parameters as it was causing duplication of styles and failing other tests.

After my changes, none of the tests failed; however, I'd like someone to please review my assumptions that invoking the `generateAndInjectStyles` method is unnecessary. 🙇‍♀