### PR TITLE
Fixed bug with styled-system to prevent undefined properties (issue #94)

### DIFF
--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -4,7 +4,7 @@ import hyphenateStyleName from './hyphenateStyleName'
 export const objToCss = (obj, prevKey) => {
   const css = Object.keys(obj).map(key => {
     if (isPlainObject(obj[key])) return objToCss(obj[key], key)
-    if (typeof obj[key] !== 'undefined') return
+    if (typeof obj[key] === 'undefined') return
     return `${hyphenateStyleName(key)}: ${obj[key]};`
   }).join(' ')
   return prevKey ? `${prevKey} {

--- a/src/utils/flatten.js
+++ b/src/utils/flatten.js
@@ -4,6 +4,7 @@ import hyphenateStyleName from './hyphenateStyleName'
 export const objToCss = (obj, prevKey) => {
   const css = Object.keys(obj).map(key => {
     if (isPlainObject(obj[key])) return objToCss(obj[key], key)
+    if (typeof obj[key] !== 'undefined') return
     return `${hyphenateStyleName(key)}: ${obj[key]};`
   }).join(' ')
   return prevKey ? `${prevKey} {


### PR DESCRIPTION
This pull request is to fix issue #94 

**Describe the bug**
When using vue-styled-components with styled-system version 5+ and you add styled-system utilities (space for example), you can see that in the CSS of the element you'll have every property of space with a value of undefined. I tested with the latest version 4 (4.2.4) of styled-system and there is no bug.

**To Reproduce**
- Start a Vue project with packages "vue-styled-components" & "styled-system" (version 5+, this is important)
- Create a styled component with prop types defined
- Put that styled component in a view
- Witness that all of it's prop types are in the CSS with undefined value

**With styled-system version 4, no bug**
https://codesandbox.io/s/vue-styledsystem-gl9z8

**With styled-system version 5, with the bug**
https://codesandbox.io/s/vue-styled-system-v3r91

**Expected behavior**
Since in Vue we need to define all prop types, the css ends up with lots of undefined values. There should be no undefined properties when these properties have no value. When a property has a value, it should end up with the correct value in the style - this part currently works.

**Screenshots**
Here you can see the undefined properties
<img width="840" alt="Screen Shot 2019-10-25 at 8 47 54 AM" src="https://user-images.githubusercontent.com/3512326/67706303-e722ca80-f98e-11e9-9684-954b12744f82.png">