### PR TITLE
Adding collectRules to expose currently inserted styelsheet rules

### DIFF
--- a/src/constructors/collectRules.js
+++ b/src/constructors/collectRules.js
@@ -1,0 +1,7 @@
+import StyleSheet from '../models/StyleSheet'
+
+const collectRules = () => {
+  return StyleSheet.rules().filter(rule => rule.cssText.length > 0)
+}
+
+export default collectRules

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import generateAlphabeticName from './utils/generateAlphabeticName'
 import css from './constructors/css'
+import collectRules from './constructors/collectRules'
 import keyframes from './constructors/keyframes'
 import injectGlobal from './constructors/injectGlobal'
 import ThemeProvider from './providers/ThemeProvider'
@@ -14,4 +15,4 @@ const styled = _styled(
 
 export default styled
 
-export { css, injectGlobal, keyframes, ThemeProvider }
+export { css, collectRules, injectGlobal, keyframes, ThemeProvider }


### PR DESCRIPTION
This adds a very basic module that returns all of the current rules off the Stylesheet singleton (While removing empty ones). The goal of this is to attempt to allow easier implementation of Server-Side Rendering and partially address #52

Example Usage in Nuxt:

```
import { collectRules } from 'vue-styled-components';

...

head() {
    if (typeof window === 'undefined') {
      const css = collectRules().map(rule => rule.cssText).join('');
      return {
        style: [{ hid: 'ssrStyles', innerHTML: css, type: 'text/css'}],
        __dangerouslyDisableSanitizers: ['style'],
      };
    }
    return {};
  }
```
This allows Nuxt/Vue Meta to inject all of the inserted rules from StyleSheet into the head of the page being rendered. Limitations being this will have to be done for each top-level "Page", but with access to the underlying rules, it should be easier to build more complete solutions.

I added this as a separate module rather than just exporting StyleSheet to allow for easier expansion in the future and to limit to scope of the exports.